### PR TITLE
[Issue 271] automate metadata inheritance

### DIFF
--- a/.github/workflows/lint-inherit-project-metadata.yml
+++ b/.github/workflows/lint-inherit-project-metadata.yml
@@ -1,0 +1,28 @@
+name: Lint - Inherit project metadata
+
+on:
+  # manual trigger
+  workflow_dispatch:
+  # trigger on PRs that affect this file or a file used to run the linter
+  pull_request:
+    paths:
+      - linters/bulk_inherit_metadata/**
+      - .github/workflows/lint-inherit-project-metadata.yml
+  # trigger on a schedule: Monday-Friday at 1am ET
+  schedule:
+    - cron: "00 5 * * 1-5"
+
+jobs:
+  run-inherit-metadata:
+    name: Run inherit project metadata
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Propagate project metadata from parent issue to sub-issues
+        run: |
+          ./linters/bulk_inherit_metadata/run.sh \
+            --org agilesix \
+            --project 17

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Local ignore files
+tmp/

--- a/linters/bulk_inherit_metadata/getProjectItems.graphql
+++ b/linters/bulk_inherit_metadata/getProjectItems.graphql
@@ -1,0 +1,76 @@
+query ($endCursor: String, $login: String!, $project: Int!, $batch: Int!) {
+  # get the project by the user login and project number
+  organization(login: $login) {
+    projectV2(number: $project) {
+      # insert the projectFields fragment below
+      ...projectFields
+    }
+  }
+}
+
+fragment projectFields on ProjectV2 {
+  # get project ID
+  id
+  # get project items in batches of 100, which is the match batch size
+  items(first: $batch, after: $endCursor) {
+    # allows us to use --paginate in the gh api call
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    # fetch details per item in the list
+    nodes {
+      ... on ProjectV2Item {
+        id
+        content {
+          ... on Issue {
+            title
+            url
+            parent {
+              url
+              projectItems(first: 3) {
+                nodes {
+                  ... on ProjectV2Item {
+                    project {
+                      number
+                      id
+                    }
+                    ...customFields
+                  }
+                }
+              }
+            }
+          }
+        }
+        ...customFields
+      }
+    }
+  }
+}
+
+fragment customFields on ProjectV2Item {
+  pillar: fieldValueByName(name: "Pillar") {
+    ... on ProjectV2ItemFieldSingleSelectValue {
+      field {
+        ...fieldId
+      }
+      optionId
+      name
+    }
+  }
+  quad: fieldValueByName(name: "Quad") {
+    ... on ProjectV2ItemFieldIterationValue {
+      field {
+        ...fieldId
+      }
+      iterationId
+      title
+    }
+  }
+}
+
+fragment fieldId on ProjectV2FieldCommon {
+  ... on ProjectV2FieldCommon {
+    id
+  }
+}

--- a/linters/bulk_inherit_metadata/getProjectItems.graphql
+++ b/linters/bulk_inherit_metadata/getProjectItems.graphql
@@ -11,7 +11,7 @@ query ($endCursor: String, $login: String!, $project: Int!, $batch: Int!) {
 fragment projectFields on ProjectV2 {
   # get project ID
   id
-  # get project items in batches of 100, which is the match batch size
+  # get project items in batches of 100, which is the max batch size
   items(first: $batch, after: $endCursor) {
     # allows us to use --paginate in the gh api call
     pageInfo {

--- a/linters/bulk_inherit_metadata/run.sh
+++ b/linters/bulk_inherit_metadata/run.sh
@@ -1,0 +1,155 @@
+#! /bin/bash
+# Propagate project metadata from parent issues to their children
+# Usage:
+# ./linters/bulk_inherit_metadata/run.sh \
+#   --org HHS \
+#   --project 12
+
+
+# #######################################################
+# Parse command line args with format `--option arg`
+# #######################################################
+
+# see this stack overflow for more details:
+# https://stackoverflow.com/a/14203146/7338319
+batch=100
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run)
+      echo "Running in dry run mode"
+      dry_run=YES
+      shift # past argument
+      ;;
+    --batch)
+      batch="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --org)
+      org="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --project)
+      project="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1") # save positional arg
+      shift # past argument
+      ;;
+  esac
+done
+
+# #######################################################
+# Set script-specific variables
+# #######################################################
+
+mkdir -p tmp
+proj_items_file="./tmp/project-items-export.json"
+to_update_file="./tmp/items-to-update.txt"
+root="./linters/bulk_inherit_metadata"
+query=$(cat "${root}/getProjectItems.graphql")
+mutation=$(cat "${root}/updateProjectFields.graphql")
+
+# #######################################################
+# Export project items
+# #######################################################
+
+gh api graphql \
+ --paginate \
+ --field login="${org}" \
+ --field project="${project}" \
+ --field batch="${batch}" \
+ --header 'GraphQL-Features:sub_issues' \
+ --header 'GraphQL-Features:issue_types' \
+ -f query="${query}" \
+ --jq ".data.organization.projectV2.items.nodes" |\
+ # combine results into a single array
+ jq --slurp 'add' |\
+ jq "[.[] |
+ # filter for the issues with a parent
+ select(.content.parent != null)]" > $proj_items_file  # write output to a file
+
+# #######################################################
+# Filter for items that need to be updated
+# #######################################################
+
+# Extract issues whose metadata conflicts with the metadata of their parent
+# Use the -c flag to condense each item to a single row in the output file
+jq -c "
+ .[] |
+
+# start editing parent object in place
+(.content.parent) |= (
+
+  # filter for the correct project
+  .projectItems.nodes[] as \$node |
+  select(\$node.project.number == ${project}) |
+
+  # pluck projectId, pillar, and quad values from node
+  {
+    projectId: \$node.project.id,
+    pillar: \$node.pillar,
+    quad: \$node.quad
+  }
+
+) |
+# end editing parent object in place
+
+  # filter for items that have metadata conflicts with parent issue
+  select((.content.parent.pillar != .pillar) or (.content.parent.quad != .quad)) |
+
+  # pluck itemId, projectId, pillar, and quad values
+  {
+    itemId: .id,
+    projectId: .content.parent.projectId,
+    pillar: .content.parent.pillar,
+    quad: .content.parent.quad,
+  }
+" $proj_items_file > $to_update_file
+
+# #######################################################
+# Create a function to update project fields
+# #######################################################
+
+function updateProjectItem()
+{
+  # assign positional args to named variables
+  data=$1
+  mutation=$2
+
+  # parse additional variables from the row data   
+  project_id=$(echo "$data" | jq --raw-output '.projectId')
+  item_id=$(echo "$data" | jq --raw-output '.itemId')
+  # pillar field and value
+  pillar_field_id=$(echo "$data" | jq --raw-output '.pillar.field.id')
+  pillar_val=$(echo "$data" | jq --raw-output '.pillar.optionId')
+  # quad field and value
+  quad_field_id=$(echo "$data" | jq --raw-output '.quad.field.id')
+  quad_val=$(echo "$data" | jq --raw-output '.quad.iterationId')
+
+  # make an API call to update project item
+  echo $"Updating item: ${item_id}"
+  gh api graphql \
+   --field projectId="${project_id}" \
+   --field itemId="${item_id}" \
+   --field pillarFieldId="${pillar_field_id}" \
+   --field pillarValue="${pillar_val}" \
+   --field quadFieldId="${quad_field_id}" \
+   --field quadValue="${quad_val}" \
+   -f query="${mutation}"
+}
+
+# #######################################################
+# Use this function to update each item
+# #######################################################
+
+while IFS= read -r row; do
+    updateProjectItem "$row" "$mutation"
+done < $to_update_file

--- a/linters/bulk_inherit_metadata/updateProjectFields.graphql
+++ b/linters/bulk_inherit_metadata/updateProjectFields.graphql
@@ -1,0 +1,40 @@
+mutation (
+  $projectId: ID!
+  $itemId: ID!
+  $pillarFieldId: ID!
+  $pillarValue: String!
+  $quadFieldId: ID!
+  $quadValue: String!
+) {
+  pillar: updateProjectV2ItemFieldValue(
+    input: {
+      projectId: $projectId
+      itemId: $itemId
+      fieldId: $pillarFieldId
+      value: { singleSelectOptionId: $pillarValue }
+    }
+  ) {
+    ...UpdateResponseFragment
+  }
+  quad: updateProjectV2ItemFieldValue(
+    input: {
+      projectId: $projectId
+      itemId: $itemId
+      fieldId: $quadFieldId
+      value: { iterationId: $quadValue }
+    }
+  ) {
+    ...UpdateResponseFragment
+  }
+}
+
+fragment UpdateResponseFragment on UpdateProjectV2ItemFieldValuePayload {
+  projectV2Item {
+    id
+    content {
+      ... on Issue {
+        url
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Automates the propagation of project metadata from a parent issue to its sub-issues.

### Changes proposed

- Adds the `linters/bulk_inherit_metadata/` sub-directory with the following files:
  - `getProjectItems.graphql` GraphQL query to export project metadata
  - `updateProjectFields.graphql` GraphQL mutation to update the project fields for a given item
  - `run.sh` A bash script that runs the steps to export project data, find discrepancies between parent and sub-issues, and update them.
- Adds the `.github/workflows/inherit-project-metadata.yml` to trigger the script

### Additional context for reviewers

Here's an example of the trigger running and successfully updating an issue with its parent's metadata:

<img width="1089" alt="Screenshot 2024-09-24 at 9 39 37 AM" src="https://github.com/user-attachments/assets/7ec9e0c0-215b-4d34-81a5-5d49ecdf84ab">
