### PR TITLE
Add GH action to rollover sprint tickets

### DIFF
--- a/.github/workflows/lint-sprint-rollover.yml
+++ b/.github/workflows/lint-sprint-rollover.yml
@@ -1,0 +1,25 @@
+name: Lint - Sprint rollover
+
+on:
+  workflow_dispatch: # for manual runs
+  schedule:
+    # Runs "at 09:00 UTC, every week on Wednesday" (see https://crontab.guru)
+    # Sprints are 2 weeks long, but crons don't easily support biweekly schedules
+    # and this GitHub action won't move tickets out of the current sprint
+    - cron: "0 9 * * 3"
+
+jobs:
+  sprint-rollover:
+    name: Roll over open tickets
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: blombard/move-to-next-iteration@master
+        with:
+          owner: agilesix
+          number: 18
+          token: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+          iteration-field: Sprint
+          iteration: last
+          new-iteration: current
+          excluded-statuses: "Done"


### PR DESCRIPTION
Rolls over open tickets from the previous sprint to the current sprint. See the [GitHub action](https://github.com/marketplace/actions/move-to-next-iteration) for more info.