### PR TITLE
[Issue 457] Bi-directional syncing for Fider

### DIFF
--- a/.github/workflows/populate-feature-base-board.yml
+++ b/.github/workflows/populate-feature-base-board.yml
@@ -1,4 +1,4 @@
-name: "Populate FeatureBase board"
+name: "Co-planning: Populate FeatureBase from GitHub"
 
 on:
   pull_request:
@@ -42,6 +42,7 @@ jobs:
             --repo "${{ github.event.repository.name }}" \
             --label proposal \
             --platform featurebase \
+            --sync-direction github-to-platform \
             --dry-run
 
       - name: Run script (real run)
@@ -51,4 +52,5 @@ jobs:
             --org "${{ github.repository_owner }}" \
             --repo "${{ github.event.repository.name }}" \
             --label proposal \
-            --platform featurebase
+            --platform featurebase \
+            --sync-direction github-to-platform

--- a/.github/workflows/update-github-from-fider.yml
+++ b/.github/workflows/update-github-from-fider.yml
@@ -1,14 +1,14 @@
-name: "Co-planning: Populate Fider from GitHub"
+name: "Co-planning:Update GitHub from Fider"
 
 on:
   pull_request:
     paths:
       - "linters/load_pb_board/**"
-      - ".github/workflows/populate-fider-board.yml"
+      - ".github/workflows/update-github-from-fider.yml"
   workflow_dispatch: # for manual runs
 
 permissions:
-  issues: read
+  issues: write
 
 defaults:
   run:
@@ -42,7 +42,7 @@ jobs:
             --repo "${{ github.event.repository.name }}" \
             --label proposal \
             --platform fider \
-            --sync-direction github-to-platform \
+            --sync-direction platform-to-github \
             --dry-run
 
       - name: Run script (real run)
@@ -53,4 +53,4 @@ jobs:
             --repo "${{ github.event.repository.name }}" \
             --label proposal \
             --platform fider \
-            --sync-direction git-to-platform
+            --sync-direction platform-to-github

--- a/linters/load_pb_board/.vscode/settings.json
+++ b/linters/load_pb_board/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.analysis.typeCheckingMode": "basic"
+}

--- a/linters/load_pb_board/__init__.py
+++ b/linters/load_pb_board/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the load_pb_board directory a Python package

--- a/linters/load_pb_board/feature_base.py
+++ b/linters/load_pb_board/feature_base.py
@@ -2,6 +2,7 @@ import json
 import re
 from typing import Any
 
+from github import GithubIssueData
 from utils import format_post_description, get_env, log, make_request
 
 FEATURE_BASE_API_TOKEN = get_env("FEATURE_BASE_API_TOKEN")
@@ -94,7 +95,7 @@ def create_post(
 
 
 def insert_new_posts(
-    github_issues: dict[str, dict],
+    github_issues: dict[str, GithubIssueData],
     post_urls: set[str],
     *,
     dry_run: bool,
@@ -108,8 +109,8 @@ def insert_new_posts(
 
         # Create new FeatureBase post
         log(f"Creating new FeatureBase post for {issue_url}")
-        title = issue_data.get("title", "")
-        description = issue_data.get("description", "")
+        title = issue_data.title
+        description = issue_data.body
 
         # Format the description using the parsing logic
         formatted_content = format_post_description(issue_url, description)

--- a/linters/load_pb_board/fider.py
+++ b/linters/load_pb_board/fider.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+from github import GithubIssueData
 from utils import format_post_description, get_env, log, make_request
 
 FIDER_API_TOKEN = get_env("FIDER_API_TOKEN")
@@ -64,7 +65,7 @@ def create_post(title: str, description: str) -> None:
 
 
 def insert_new_posts(
-    github_issues: dict[str, dict],
+    github_issues: dict[str, GithubIssueData],
     post_urls: set[str],
     *,
     dry_run: bool,
@@ -78,8 +79,8 @@ def insert_new_posts(
 
         # Create new Fider post
         log(f"Creating new Fider post for {issue_url}")
-        title = issue_data.get("title", "")
-        description = issue_data.get("description", "")
+        title = issue_data.title
+        description = issue_data.body
 
         # Format the description using the parsing logic
         formatted_description = format_post_description(issue_url, description)

--- a/linters/load_pb_board/fider.py
+++ b/linters/load_pb_board/fider.py
@@ -6,6 +6,7 @@ from utils import format_post_description, get_env, log, make_request
 
 FIDER_API_TOKEN = get_env("FIDER_API_TOKEN")
 BOARD = get_env("FIDER_BOARD")
+FIDER_URL = f"https://{BOARD}.fider.io"
 
 # #######################################################
 # Fider - fetch and parse posts
@@ -16,7 +17,7 @@ def fetch_posts() -> dict[str, PostData]:
     """Fetch Fider posts using the API and return PostData keyed by GitHub issue URLs."""
     log(f"Fetching current Fider posts from {BOARD}.fider.io")
 
-    url = f"https://{BOARD}.fider.io/api/v1/posts"
+    url = f"{FIDER_URL}/api/v1/posts"
     headers = {"Authorization": f"Bearer {FIDER_API_TOKEN}"}
 
     posts = make_request(url, headers)
@@ -44,7 +45,7 @@ def parse_posts(posts: list[dict], fider_url: str) -> dict[str, PostData]:
         if not matches:
             continue
         github_url = matches[0]  # Take the first match
-        fider_url = f"{fider_url}/{post.get('number')}"
+        fider_url = f"{FIDER_URL}/posts/{post.get('number')}"
         posts_dict[github_url] = PostData(
             url=fider_url,
             vote_count=post.get("votesCount", 0),

--- a/linters/load_pb_board/github.py
+++ b/linters/load_pb_board/github.py
@@ -145,7 +145,7 @@ def update_github_issue(
 
 def update_github_issues(
     issues: dict[str, GithubIssueData],
-    posts: list[PostData],
+    posts: dict[str, PostData],
     *,
     dry_run: bool,
 ) -> None:
@@ -156,11 +156,11 @@ def update_github_issues(
 
     log(f"Processing {len(posts)} posts (dry_run: {dry_run})")
 
-    for post in posts:
+    for issue_url, post in posts.items():
         # Get the issue data
-        issue = issues.get(post.github_url)
+        issue = issues.get(issue_url)
         if not issue:
-            log(f"Issue not found for post {post.github_url}")
+            log(f"Issue not found for post {issue_url}")
             continue
 
         log(f"Processing issue #{issue.number} in {issue.org}/{issue.repo}")

--- a/linters/load_pb_board/github.py
+++ b/linters/load_pb_board/github.py
@@ -3,10 +3,59 @@
 GitHub API functionality for fetching issues.
 """
 
+import json
+import re
 import urllib.parse
-from utils import get_env, log, make_request
+from dataclasses import dataclass, field
+from utils import format_issue_body, get_env, log, make_request
 
 GITHUB_API_TOKEN = get_env("GITHUB_API_TOKEN")
+
+
+@dataclass
+class GithubIssueData:
+    """Data class for GitHub issue data."""
+
+    org: str
+    repo: str
+    number: int
+    title: str = ""
+    body: str = ""
+    labels: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PostData:
+    """Data class for Fider or FeatureBase post data."""
+
+    url: str
+    vote_count: int
+    github_url: str
+
+
+# ############################################################################
+# Parse issue URL
+# ############################################################################
+
+
+def parse_issue_url(issue_url: str) -> GithubIssueData:
+    """Parse the issue URL and return the org, repo, and issue number."""
+    pattern = (
+        r"https://github\.com/(?P<org>[\w-]+)/(?P<repo>[\w-]+)/issues/(?P<issue>\d+)"
+    )
+    match = re.match(pattern, issue_url)
+    if not match:
+        raise ValueError(f"Invalid GitHub issue URL: {issue_url}")
+    return GithubIssueData(
+        org=match.group("org"),
+        repo=match.group("repo"),
+        number=int(match.group("issue")),
+    )
+
+
+# ############################################################################
+# Fetch GitHub issues
+# ############################################################################
 
 
 def fetch_github_issues(
@@ -15,7 +64,7 @@ def fetch_github_issues(
     label: str,
     state: str = "open",
     batch: int = 100,
-) -> dict[str, dict]:
+) -> dict[str, GithubIssueData]:
     """Fetch GitHub issues using the GitHub API."""
     log(f"Fetching {state} issues from {org}/{repo} with label '{label}'")
 
@@ -39,7 +88,7 @@ def fetch_github_issues(
     issues_data = make_request(full_url, headers)
 
     # Convert to the same format as the original script
-    issues_dict = {}
+    issues_dict: dict[str, GithubIssueData] = {}
     for issue in issues_data:
         issue_url = issue.get("html_url")
         issue_title = issue.get("title")
@@ -49,11 +98,94 @@ def fetch_github_issues(
             continue
 
         # Add to dict
-        issues_dict[issue_url] = {
-            "title": issue_title,
-            "description": issue.get("body", ""),
-            "labels": [label["name"] for label in issue.get("labels", [])],
-        }
+        issues_dict[issue_url] = GithubIssueData(
+            org=org,
+            repo=repo,
+            number=issue.get("number"),
+            title=issue_title,
+            body=issue.get("body", ""),
+        )
 
     log(f"Found {len(issues_dict)} GitHub issues")
     return issues_dict
+
+
+# ############################################################################
+# Update GitHub issues
+# ############################################################################
+
+
+def update_github_issue(
+    org: str,
+    repo: str,
+    issue_number: int,
+    issue_body: str,
+) -> None:
+    """Update a GitHub issue."""
+    log(f"Updating GitHub issue #{issue_number} in {org}/{repo}")
+
+    headers = {
+        "Authorization": f"token {GITHUB_API_TOKEN}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+
+    url = f"https://api.github.com/repos/{org}/{repo}/issues/{issue_number}"
+
+    # Prepare the data to update
+    data = {"body": issue_body}
+
+    # Make PATCH request to update the issue
+    response = make_request(url, headers, method="PATCH", data=json.dumps(data))
+
+    if response:
+        log(f"Successfully updated GitHub issue #{issue_number}")
+    else:
+        log(f"Failed to update GitHub issue #{issue_number}")
+
+
+def update_github_issues(
+    issues: dict[str, GithubIssueData],
+    posts: list[PostData],
+    *,
+    dry_run: bool,
+) -> None:
+    """Update GitHub issues with data from Fider or FeatureBase posts."""
+    if not posts:
+        log("No posts to update")
+        return
+
+    log(f"Processing {len(posts)} posts (dry_run: {dry_run})")
+
+    for post in posts:
+        # Get the issue data
+        issue = issues.get(post.github_url)
+        if not issue:
+            log(f"Issue not found for post {post.github_url}")
+            continue
+
+        log(f"Processing issue #{issue.number} in {issue.org}/{issue.repo}")
+
+        # Format the new issue body
+        issue_body = format_issue_body(
+            current_body=issue.body,
+            section="Fider",
+            post_url=post.url,
+            vote_count=post.vote_count,
+        )
+
+        # Skip update if dry run
+        if dry_run:
+            log(
+                f"[DRY RUN] Would update issue #{issue.number} with post URL: {post.url}"
+            )
+            continue
+
+        # Update the GitHub issue
+        update_github_issue(
+            org=issue.org,
+            repo=issue.repo,
+            issue_number=issue.number,
+            issue_body=issue_body,
+        )
+
+    log("Finished processing all posts")

--- a/linters/load_pb_board/github.py
+++ b/linters/load_pb_board/github.py
@@ -163,7 +163,9 @@ def update_github_issues(
             log(f"Issue not found for post {issue_url}")
             continue
 
-        log(f"Processing issue #{issue.number} in {issue.org}/{issue.repo}")
+        log(
+            f"Processing issue https://github.com/{issue.org}/{issue.repo}/issues/{issue.number}"
+        )
 
         # Format the new issue body
         issue_body = format_issue_body(

--- a/linters/load_pb_board/pyproject.toml
+++ b/linters/load_pb_board/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=61.0"]
+
+[project]
+name = "load_pb_board"
+version = "0.1.0"

--- a/linters/load_pb_board/run.py
+++ b/linters/load_pb_board/run.py
@@ -7,6 +7,7 @@ Usage: From the root of the load_pb_board/ directory:
     --repo simpler-grants-sandbox \
     --label proposal \
     --platform fider \
+    --sync-direction github-to-platform \
     --dry-run
 """
 
@@ -31,6 +32,7 @@ class CliArgs:
     repo: str
     label: str
     platform: str
+    sync_direction: str = "github-to-platform"
     state: str = "open"
     batch: int = 100
     dry_run: bool = False
@@ -44,6 +46,12 @@ def parse_args() -> CliArgs:
     parser.add_argument("--org", required=True, help="GitHub organization")
     parser.add_argument("--repo", required=True, help="GitHub repository")
     parser.add_argument("--label", required=True, help="GitHub issue label")
+    parser.add_argument(
+        "--sync-direction",
+        required=True,
+        choices=["github-to-platform", "platform-to-github"],
+        help="Sync direction (github-to-platform or platform-to-github)",
+    )
     parser.add_argument(
         "--platform",
         required=True,
@@ -60,6 +68,7 @@ def parse_args() -> CliArgs:
         repo=args.repo,
         label=args.label,
         platform=args.platform,
+        sync_direction=args.sync_direction,
         state=args.state,
         batch=args.batch,
         dry_run=args.dry_run,
@@ -186,7 +195,10 @@ def main() -> int:
         log("Running in dry run mode")
 
     if args.platform == "fider":
-        load_fider_from_github(args)
+        if args.sync_direction == "github-to-platform":
+            load_fider_from_github(args)
+        elif args.sync_direction == "platform-to-github":
+            update_github_from_fider(args)
     elif args.platform == "featurebase":
         load_featurebase_from_github(args)
 

--- a/linters/load_pb_board/run.py
+++ b/linters/load_pb_board/run.py
@@ -5,12 +5,13 @@ Usage: From the root of the load_pb_board/ directory:
   python run.py \
     --org agilesix \
     --repo simpler-grants-sandbox \
-    --label label \
+    --label proposal \
     --platform fider \
     --dry-run
 """
 
 import argparse
+from dataclasses import dataclass
 
 import fider
 import feature_base
@@ -18,11 +19,25 @@ from github import fetch_github_issues
 from utils import log
 
 # #######################################################
-# Main
+# CLI Argument Parsing
 # #######################################################
 
 
-def main() -> int:
+@dataclass
+class CliArgs:
+    """Command line arguments for the application."""
+
+    org: str
+    repo: str
+    label: str
+    platform: str
+    state: str = "open"
+    batch: int = 100
+    dry_run: bool = False
+
+
+def parse_args() -> CliArgs:
+    """Parse command line arguments and return a CliArgs dataclass."""
     parser = argparse.ArgumentParser(
         description="Load GitHub issues into Fider or FeatureBase board"
     )
@@ -40,10 +55,24 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true", help="Dry run mode")
 
     args = parser.parse_args()
+    return CliArgs(
+        org=args.org,
+        repo=args.repo,
+        label=args.label,
+        platform=args.platform,
+        state=args.state,
+        batch=args.batch,
+        dry_run=args.dry_run,
+    )
 
-    if args.dry_run:
-        log("Running in dry run mode")
 
+# #######################################################
+# Fider Operations
+# #######################################################
+
+
+def load_fider_from_github(args: CliArgs) -> None:
+    """Fetch GitHub issues and use them to populate a Fider board."""
     # Fetch GitHub issues
     github_issues = fetch_github_issues(
         org=args.org,
@@ -53,43 +82,113 @@ def main() -> int:
         batch=args.batch,
     )
 
+    # Fetch Fider posts
+    fider_posts = fider.fetch_posts()
+
+    # Extract GitHub URLs from Fider posts
+    post_urls = fider.extract_github_urls_from_posts(
+        posts=fider_posts,
+        org=args.org,
+        repo=args.repo,
+    )
+
+    # Check which GitHub issues need to be added
+    log("Checking which GitHub issues need to be added to Fider")
+    fider.insert_new_posts(
+        github_issues=github_issues,
+        post_urls=post_urls,
+        dry_run=args.dry_run,
+    )
+
+
+def update_github_from_fider(args: CliArgs) -> None:
+    """Fetch posts from Fider and use them to update issues in GitHub."""
+    # Fetch Fider posts
+    fider_posts = fider.fetch_posts()
+
+    # Extract GitHub URLs from Fider posts
+    fider.extract_github_urls_from_posts(
+        posts=fider_posts,
+        org=args.org,
+        repo=args.repo,
+    )
+
+    # Update GitHub issues based on Fider posts
+    log("Updating GitHub issues based on Fider posts")
+    # TODO: Implement GitHub issue updates based on Fider posts
+    if args.dry_run:
+        log("Dry run: Would update GitHub issues from Fider posts")
+
+
+# #######################################################
+# FeatureBase Operations
+# #######################################################
+
+
+def load_featurebase_from_github(args: CliArgs) -> None:
+    """Fetch GitHub issues and use them to populate a FeatureBase board."""
+    # Fetch GitHub issues
+    github_issues = fetch_github_issues(
+        org=args.org,
+        repo=args.repo,
+        label=args.label,
+        state=args.state,
+        batch=args.batch,
+    )
+
+    # Fetch FeatureBase posts
+    featurebase_posts = feature_base.fetch_posts()
+
+    # Extract GitHub URLs from FeatureBase posts
+    post_urls = feature_base.extract_github_urls_from_posts(
+        posts=featurebase_posts,
+        org=args.org,
+        repo=args.repo,
+    )
+
+    # Check which GitHub issues need to be added
+    log("Checking which GitHub issues need to be added to FeatureBase")
+    feature_base.insert_new_posts(
+        github_issues=github_issues,
+        post_urls=post_urls,
+        dry_run=args.dry_run,
+    )
+
+
+def update_github_from_featurebase(args: CliArgs) -> None:
+    """Fetch posts from FeatureBase and use them to update issues in GitHub."""
+    # Fetch FeatureBase posts
+    featurebase_posts = feature_base.fetch_posts()
+
+    # Extract GitHub URLs from FeatureBase posts
+    feature_base.extract_github_urls_from_posts(
+        posts=featurebase_posts,
+        org=args.org,
+        repo=args.repo,
+    )
+
+    # Update GitHub issues based on FeatureBase posts
+    log("Updating GitHub issues based on FeatureBase posts")
+    # TODO: Implement GitHub issue updates based on FeatureBase posts
+    if args.dry_run:
+        log("Dry run: Would update GitHub issues from FeatureBase posts")
+
+
+# #######################################################
+# Main
+# #######################################################
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.dry_run:
+        log("Running in dry run mode")
+
     if args.platform == "fider":
-        # Fetch Fider posts
-        fider_posts = fider.fetch_posts()
-
-        # Extract GitHub URLs from Fider posts
-        post_urls = fider.extract_github_urls_from_posts(
-            posts=fider_posts,
-            org=args.org,
-            repo=args.repo,
-        )
-
-        # Check which GitHub issues need to be added
-        log("Checking which GitHub issues need to be added to Fider")
-        fider.insert_new_posts(
-            github_issues=github_issues,
-            post_urls=post_urls,
-            dry_run=args.dry_run,
-        )
-
+        load_fider_from_github(args)
     elif args.platform == "featurebase":
-        # Fetch FeatureBase posts
-        featurebase_posts = feature_base.fetch_posts()
-
-        # Extract GitHub URLs from FeatureBase posts
-        post_urls = feature_base.extract_github_urls_from_posts(
-            posts=featurebase_posts,
-            org=args.org,
-            repo=args.repo,
-        )
-
-        # Check which GitHub issues need to be added
-        log("Checking which GitHub issues need to be added to FeatureBase")
-        feature_base.insert_new_posts(
-            github_issues=github_issues,
-            post_urls=post_urls,
-            dry_run=args.dry_run,
-        )
+        load_featurebase_from_github(args)
 
     return 0  # success
 

--- a/linters/load_pb_board/utils.py
+++ b/linters/load_pb_board/utils.py
@@ -134,14 +134,12 @@ def format_issue_body(
         # Section exists, update it with new post URL and vote count
         # Find the section and replace its content
         pattern = rf"({re.escape(section_header)}.*?)(?=\n###|\Z)"
-        replacement = f"{section_header}\n\n- [Post]({post_url})\n- Votes: {vote_count}"
+        replacement = f"{section_header}\n\n- Vote for this feature: [Post]({post_url})\n- Votes: {vote_count}"
 
         # Use re.sub with DOTALL flag to match across multiple lines
         updated_body = re.sub(pattern, replacement, current_body, flags=re.DOTALL)
         return updated_body
     else:
         # Section doesn't exist, append it at the bottom
-        new_section = (
-            f"\n\n{section_header}\n\n- [Post]({post_url})\n- Votes: {vote_count}"
-        )
+        new_section = f"\n\n{section_header}\n\n- Vote for this feature: [Post]({post_url})\n- Votes: {vote_count}"
         return current_body + new_section

--- a/linters/load_pb_board/utils.py
+++ b/linters/load_pb_board/utils.py
@@ -117,3 +117,31 @@ def format_post_description(url: str, description: str) -> str:
 
     # Format with GitHub link and summary
     return f"{summary}\n\n[GitHub issue]({url})"
+
+
+def format_issue_body(
+    current_body: str,
+    section: str,
+    post_url: str,
+    vote_count: int,
+) -> str:
+    """Updates or adds a section to the issue body for Fider or FeatureBase."""
+    # Create the section header to search for
+    section_header = f"### {section.title()}"
+
+    # Check if the section already exists
+    if section_header in current_body:
+        # Section exists, update it with new post URL and vote count
+        # Find the section and replace its content
+        pattern = rf"({re.escape(section_header)}.*?)(?=\n###|\Z)"
+        replacement = f"{section_header}\n\n- [Post]({post_url})\n- Votes: {vote_count}"
+
+        # Use re.sub with DOTALL flag to match across multiple lines
+        updated_body = re.sub(pattern, replacement, current_body, flags=re.DOTALL)
+        return updated_body
+    else:
+        # Section doesn't exist, append it at the bottom
+        new_section = (
+            f"\n\n{section_header}\n\n- [Post]({post_url})\n- Votes: {vote_count}"
+        )
+        return current_body + new_section


### PR DESCRIPTION
### Summary

Supports bi-directional syncing between GitHub and Fider

- Fixes https://github.com/HHS/grants-product-and-delivery/issues/457
- Time to review: 5 minutes

### Changes proposed

- Refactors `run.py` and `fider.py`
- Adds support for `--sync-direction` CLI arg which supports `github-to-platform` and `platform-to-github`
- Adds `update_github_issues()` function to update GitHub issues with Fider link and vote count
- Adds a new GitHub action to update tickets with data from Fider

### Context for reviewers

Here's a screenshot of the section updated by Fider (also at the bottom of [this ticket](https://github.com/agilesix/simpler-grants-sandbox/issues/18))

<img width="950" height="718" alt="Screenshot 2025-08-25 at 2 52 53 PM" src="https://github.com/user-attachments/assets/ea47a7da-1f22-4eee-ada6-99208e69bf03" />

Here's a screenshot of the dry run:

<img width="1069" height="740" alt="Screenshot 2025-08-25 at 2 54 21 PM" src="https://github.com/user-attachments/assets/53b8f8be-01f2-4604-bdaa-3d9beb4aaa1e" />
